### PR TITLE
Fixed asset pipeline issues with patternfly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ end
 
 # Use SCSS for stylesheets and patternfly
 # Install it wil bower, not as a gem, to install JS dependencies
-gem 'patternfly-sass', '~> 3.8'
+gem 'patternfly-sass', '~> 3.8.0'
 #
 # Devise
 #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.1.5)
   minitest
-  patternfly-sass (~> 3.8)
+  patternfly-sass (~> 3.8.0)
   pg
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,8 +12,8 @@
 //
 
 //= require jquery
-//= require patternfly
 //= require bootstrap
+//= require patternfly
 //= require bootstrap-datepicker
 //= require bootstrap-select
 //= require bootstrap-switch

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,14 +5,7 @@
     = csrf_meta_tags
 
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
 
   %body
     = yield
-
-  <!-- jQuery -->
-<script src="bower_components/jquery/dist/jquery.min.js"></script>
-<!-- Bootstrap -->
-<script src="bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
-<!-- PatternFly -->
-<script src="bower_components/patternfly/dist/js/patternfly.min.js"></script>
+    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
     "tests"
   ],
   "dependencies": {
-    "patternfly-sass": "^3.8.0"
+    "angular-patternfly-sass": "^3.8.0"
   }
 }


### PR DESCRIPTION
The JS assets needs to be required ONLY in the application.js file,
and then this file is loaded by `javascript_link_tag('application')`.

PatternFly needs to be included as a bower dependency if you want to
have its JS dependencies. Unfortunately there is no other way :(
I assume that angular will be used in this repo, so I changed the
bower dependecy to `angular-patternfly-sass` which also loads the
JS deps the same way as `patternfly-sass`.