### PR TITLE
Adding 'Cancel' button to Edit_Room view

### DIFF
--- a/app/views/rooms/edit.html.haml
+++ b/app/views/rooms/edit.html.haml
@@ -7,4 +7,5 @@
     .form-group.actions
       .col-sm-offset-2.col-sm-10
         = link_to (t "application.models.room.delete_room").titleize, room_path(@room), class:"btn btn-danger btn-lg", method: :delete
-        = f.submit t("application.models.room.edit_room").titleize, class:"btn btn-primary btn-lg"    
+        = f.submit t("application.models.room.edit_room").titleize, class:"btn btn-primary btn-lg"
+        = link_to (t "application.models.room.cancel_edit_room").titleize, rooms_path, class:"btn btn-lg btn-default"    

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,7 +54,7 @@ en:
     reports:                "reports"
     dashboard:              "dashboard"
     models:
-      errors_prohibited_saving: "prohibited this %{model} from being saved" 
+      errors_prohibited_saving: "prohibited this %{model} from being saved"
       room:
         room:                   "room"
         name:                   "name"
@@ -64,6 +64,7 @@ en:
         delete_room:            "delete room"
         update_room:            "update room"
         edit_room:              "edit room"
+        cancel_edit_room:       "cancel"
         room_added:             "room added"
         room_deleted:           "room deleted"
         room_not_added:         "room could not be added"


### PR DESCRIPTION
# Purpose or Intent

The goal of this PR is to cover the following

- Fix issue #8 (**adding a new Cancel button** to the Edit_Room view. In this way user's are able to go back to the Room_Index view without making any changes)