### PR TITLE
Added no same start/end time in shifts (with spec)

### DIFF
--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -11,7 +11,7 @@ class Shift < ApplicationRecord
   validates :end_time, format: { with: REGEX, message: I18n.t("bad_format", scope: SCOPE) }
   validates_each :end_time do |shift|
     shift.errors.add(:shift, I18n.t("end_time_earlier_than_start_time", scope: SCOPE + ".attributes.end_time")) if
-                     shift.start_time > shift.end_time
+                     shift.start_time >= shift.end_time
   end
 
   validates :sites_reserved, numericality: { only_integer: true }

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe Shift, type: :model do
     expect(shift).not_to be_valid
     expect(shift.errors[:shift]).to include "should be later than init_time"
   end
+
+  it "start_time equal to end_time is invalid." do
+    shift.start_time = "10:00"
+    shift.end_time = "10:00"
+    shift.valid?
+    expect(shift).not_to be_valid
+    expect(shift.errors[:shift]).to include "should be later than init_time"
+  end
   context "Shift::" do
     let!(:room)  { FactoryGirl.create(:room, capacity: 20) }
     let!(:room2) { FactoryGirl.create(:room, capacity: 20) }


### PR DESCRIPTION
# Purpose or Intent

- The goal of this PR is to fix the following issue: 

- Issue #18   (**Start/End time** cannot have the same value 

For more information feel free to access the link to the mentioned issue.