### PR TITLE
Add confirmation to deleting room and shift

### DIFF
--- a/app/views/admin/rooms/_add_shift.html.haml
+++ b/app/views/admin/rooms/_add_shift.html.haml
@@ -1,5 +1,5 @@
 .container
   %p
     = link_to (t "application.models.room.edit_room").capitalize, edit_admin_room_path(room), class: "btn btn-lg btn-default"
-    = link_to (t "application.models.room.delete_room").capitalize, admin_room_path(room), class: "btn btn-lg btn-danger", method: :delete    
+    = link_to (t "application.models.room.delete_room").capitalize, admin_room_path(room), class: "btn btn-lg btn-danger", method: :delete, data: { confirm: t('.irreversible') }    
     = link_to (t "application.models.shift.add_shift").capitalize, new_admin_room_shift_path(room), class: "btn btn-lg btn-primary"

--- a/app/views/admin/rooms/_add_shift.html.haml
+++ b/app/views/admin/rooms/_add_shift.html.haml
@@ -1,5 +1,6 @@
 .container
   %p
     = link_to (t "application.models.room.edit_room").capitalize, edit_admin_room_path(room), class: "btn btn-lg btn-default"
-    = link_to (t "application.models.room.delete_room").capitalize, admin_room_path(room), class: "btn btn-lg btn-danger", method: :delete, data: { confirm: t('.irreversible') }    
+    = link_to (t "application.models.room.delete_room").capitalize, admin_room_path(room), class: "btn btn-lg btn-danger", method: :delete,
+      data: { confirm: t('.irreversible') }    
     = link_to (t "application.models.shift.add_shift").capitalize, new_admin_room_shift_path(room), class: "btn btn-lg btn-primary"

--- a/app/views/admin/rooms/edit.html.haml
+++ b/app/views/admin/rooms/edit.html.haml
@@ -6,6 +6,7 @@
     = render 'room_form', f: f
     .form-group.actions
       .col-sm-offset-2.col-sm-10
-        = link_to (t "application.models.room.delete_room").titleize, admin_room_path(@room), class: "btn btn-lg btn-danger", method: :delete, data: { confirm: t('.irreversible') }  
+        = link_to (t "application.models.room.delete_room").titleize, admin_room_path(@room), class: "btn btn-lg btn-danger", method: :delete,
+          data: { confirm: t('.irreversible') }  
         = f.submit t("application.models.room.update_room").titleize, class: "btn btn-lg btn-primary"
         = link_to (t "application.models.room.cancel_edit_room").titleize, admin_rooms_path, class: "btn btn-lg btn-default"

--- a/app/views/admin/rooms/edit.html.haml
+++ b/app/views/admin/rooms/edit.html.haml
@@ -6,6 +6,6 @@
     = render 'room_form', f: f
     .form-group.actions
       .col-sm-offset-2.col-sm-10
-        = link_to (t "application.models.room.delete_room").titleize, admin_room_path(@room), class: "btn btn-danger btn-lg", method: :delete
-        = f.submit t("application.models.room.update_room").titleize, class: "btn btn-primary btn-lg"
-        = link_to (t "application.models.room.cancel_edit_room").titleize, admin_rooms_path, class: "btn btn-lg btn-default"    
+        = link_to (t "application.models.room.delete_room").titleize, admin_room_path(@room), class: "btn btn-lg btn-danger", method: :delete, data: { confirm: t('.irreversible') }  
+        = f.submit t("application.models.room.update_room").titleize, class: "btn btn-lg btn-primary"
+        = link_to (t "application.models.room.cancel_edit_room").titleize, admin_rooms_path, class: "btn btn-lg btn-default"

--- a/app/views/admin/shifts/edit.html.haml
+++ b/app/views/admin/shifts/edit.html.haml
@@ -7,6 +7,7 @@
     .container
       .form-group
         .actions
-          = link_to (t "application.models.shift.delete_shift").titleize, admin_shift_path(@shift), class: "btn btn-lg btn-danger", method: :delete, data: { confirm: t('.irreversible') }
+          = link_to (t "application.models.shift.delete_shift").titleize, admin_shift_path(@shift), class: "btn btn-lg btn-danger", method: :delete,
+            data: { confirm: t('.irreversible') }
           = f.submit (t "application.models.shift.update_shift").titleize, class: "btn btn-lg btn-primary", method: :update
           = link_to (t "application.models.shift.cancel_edit_shift").titleize, admin_shift_path(@shift), class: "btn btn-lg btn-default"

--- a/app/views/admin/shifts/edit.html.haml
+++ b/app/views/admin/shifts/edit.html.haml
@@ -7,6 +7,6 @@
     .container
       .form-group
         .actions
-          = link_to (t "application.models.shift.delete_shift").titleize, admin_shift_path(@shift), class: "btn btn-danger btn-lg", method: :delete
-          = f.submit (t "application.models.shift.update_shift").titleize, class: "btn btn-primary btn-lg", method: :update
-          = link_to (t "application.models.shift.cancel_edit_shift").titleize, admin_shift_path(@shift), class: "btn btn-default btn-lg"
+          = link_to (t "application.models.shift.delete_shift").titleize, admin_shift_path(@shift), class: "btn btn-lg btn-danger", method: :delete, data: { confirm: t('.irreversible') }
+          = f.submit (t "application.models.shift.update_shift").titleize, class: "btn btn-lg btn-primary", method: :update
+          = link_to (t "application.models.shift.cancel_edit_shift").titleize, admin_shift_path(@shift), class: "btn btn-lg btn-default"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,12 @@ en:
         total_capacity:        "capacity on all shifts"
         refresh:               "refresh"
         space_available:       "space available"
+    rooms:
+      add_shift:
+        irreversible:           "Are you sure? The following action can not be undone"
+    shifts:
+      edit:
+        irreversible:           "Are you sure? The following action can not be undone"
   application:
     name:                   "Shift Reservation"
     about:                  "about"


### PR DESCRIPTION
This PR replaced the PR #21.

- Create confirmation to deleting rooms. Fix issue #15 
![delete_rooms](https://cloud.githubusercontent.com/assets/19265820/18348937/a9b751ee-75ce-11e6-9aa4-3afe78653bee.gif)

- Create confirmation to deleting shifts
![delete_shift](https://cloud.githubusercontent.com/assets/19265820/18348941/ad259bb0-75ce-11e6-82ab-3440272a37db.gif)