### PR TITLE
Global lock in fix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
 
   def system_locked_in?
     if Myconfig.global_lock?
-      flash[:error] = t "global_lock_error"
+      flash[:alert] = t "global_lock_error"
       redirect_to root_path
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,4 +20,11 @@ class ApplicationController < ActionController::Base
       devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name, :phone, :password])
     end
   end
+
+  def system_locked_in?
+    if Myconfig.global_lock?
+      flash[:error] = t "global_lock_error"
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/information_controller.rb
+++ b/app/controllers/information_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class InformationController < ApplicationController
   def info
   end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,4 +1,4 @@
-class RoomsController < ApplicationController
+class RoomsController < UserAuthenticatedController
   def index
     @rooms = Room.all
   end

--- a/app/controllers/user/assignments_controller.rb
+++ b/app/controllers/user/assignments_controller.rb
@@ -1,4 +1,6 @@
 class User::AssignmentsController < UserAuthenticatedController
+  before_action :system_locked_in?, except: [:destroy]
+
   def new
     unless (@offspring = Offspring.find_by(id: params[:offspring_id], user: current_user))
       flash[:alert] = t ".offspring_not_found"

--- a/app/controllers/user/offsprings_controller.rb
+++ b/app/controllers/user/offsprings_controller.rb
@@ -1,4 +1,6 @@
 class User::OffspringsController < UserAuthenticatedController
+  before_action :system_locked_in?, except: [:show, :index, :destroy]
+
   def index
     @offsprings = current_user.offsprings
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,7 +20,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  global_lock_error:         "The systems is locked. No changes are allowed"
   layouts:
     admin_header:
       users:                 "Users"

--- a/spec/controllers/rooms_controller_spec.rb
+++ b/spec/controllers/rooms_controller_spec.rb
@@ -1,4 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe RoomsController, type: :controller do
-end


### PR DESCRIPTION
Adding fix for global lock int. When it is no, only show actions are allowed for offspring and assignments.

Closes #87 